### PR TITLE
Bump minimum Node.js version requirement to 22.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "turbo run build",

--- a/packages/e2e-core/package.json
+++ b/packages/e2e-core/package.json
@@ -4,9 +4,6 @@
   "description": "End-to-end tests for tinytsdi library",
   "private": true,
   "type": "module",
-  "engines": {
-    "node": ">=24.0.0"
-  },
   "scripts": {
     "e2e:test:run": "vitest run",
     "e2e:test": "vitest",

--- a/packages/e2e-core/package.json
+++ b/packages/e2e-core/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "e2e:test:run": "vitest run",

--- a/packages/tinytsdi/package.json
+++ b/packages/tinytsdi/package.json
@@ -26,7 +26,7 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "rm -rf dist && vite build",

--- a/packages/tinytsdi/package.json
+++ b/packages/tinytsdi/package.json
@@ -26,7 +26,7 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "rm -rf dist && vite build",


### PR DESCRIPTION
## Summary
Updated the minimum required Node.js version from 20.0.0 to 22.0.0 across relevant packages.

## Changes
- Updated root `package.json` engine requirement to `>=22.0.0`
- Updated `packages/tinytsdi/package.json` engine requirement to `>=22.0.0`
- Removed redundant `engines` field from `packages/e2e-core/package.json` (internal/unpublished package — root coverage is sufficient)

## Details
Node.js 22 is the current Active LTS release (since October 2024). Setting the minimum to 22 follows the standard LTS progression and avoids excluding users still on Node.js 22 LTS. The `engines` field is only needed in the root (dev guard) and the published `tinytsdi` package (for npm consumers).
